### PR TITLE
fix(intake): show model name in upload intake destination step (#1638)

### DIFF
--- a/homeassistant/packages/3d_printing/common/dashboards/_resources.yaml
+++ b/homeassistant/packages/3d_printing/common/dashboards/_resources.yaml
@@ -9,7 +9,7 @@
   type: module
 - url: /local/3d_printing/printer_controls/bambu-move-axis-card.js
   type: module
-- url: /local/3d_printing/model_catalog/model-catalog-intake-cards.js?v=257
+- url: /local/3d_printing/model_catalog/model-catalog-intake-cards.js?v=258
   type: module
 - url: /local/3d_printing/model_catalog/model-catalog-browser-card.js?v=234
   type: module

--- a/homeassistant/www/3d_printing/model_catalog/model-catalog-intake-cards.js
+++ b/homeassistant/www/3d_printing/model_catalog/model-catalog-intake-cards.js
@@ -1,4 +1,4 @@
 import './model-catalog-intake-shared.js?v=38';
 import './model-catalog-intake-home-card.js?v=113';
-import './model-catalog-intake-wizard-overrides.js?v=140';
+import './model-catalog-intake-wizard-overrides.js?v=141';
 import './model-catalog-inbox-review-card.js?v=35';

--- a/homeassistant/www/3d_printing/model_catalog/model-catalog-intake-wizard-overrides.js
+++ b/homeassistant/www/3d_printing/model_catalog/model-catalog-intake-wizard-overrides.js
@@ -2358,7 +2358,19 @@ function getExcludedItemsUnderPath(parentPath, excludedItems) {
       var detectedMerged = detected && detected.merged ? detected.merged : null;
       var sourceCatalogModelId = String((detectedMerged && detectedMerged.source_catalog_model_id) || '').trim();
       var sourceCatalogTitle = String((detectedMerged && detectedMerged.display_title) || model.title || sourceCatalogModelId || '').trim();
-      nextPlans.push(Object.assign({
+      // Issue #1638: compute selected_summary from model title even when
+      // source_catalog_model_id is absent (browser upload has no .modelmeta.json).
+      var modelTitle = String(model.title || '').trim();
+      var autoSummary = sourceCatalogModelId ? {
+        id: sourceCatalogModelId,
+        primary: sourceCatalogTitle || sourceCatalogModelId,
+        secondary: sourceCatalogModelId,
+      } : (modelTitle ? {
+        id: '',
+        primary: modelTitle,
+        secondary: '',
+      } : null);
+      var merged = Object.assign({
         _group_key: groupKey,
         destination: 'curated',
         match_mode: sourceCatalogModelId ? 'republish_as_new_version' : 'new',
@@ -2367,14 +2379,18 @@ function getExcludedItemsUnderPath(parentPath, excludedItems) {
         lookup_results: [],
         lookup_loading: false,
         lookup_error: '',
-        selected_summary: sourceCatalogModelId ? {
-          id: sourceCatalogModelId,
-          primary: sourceCatalogTitle || sourceCatalogModelId,
-          secondary: sourceCatalogModelId,
-        } : null,
+        selected_summary: autoSummary,
       }, previous || {}, {
         _group_key: groupKey,
-      }));
+      });
+      // Issue #1638: always refresh selected_summary from the current model
+      // title when match_mode is 'new'. 'New' mode has no user lookup
+      // selection to preserve, so the summary should reflect the latest
+      // title from the Organize step (including user renames).
+      if (String(merged.match_mode || '').trim().toLowerCase() === 'new') {
+        merged.selected_summary = autoSummary;
+      }
+      nextPlans.push(merged);
     }
     this._groupDestinations = nextPlans;
     return nextPlans;
@@ -2456,6 +2472,13 @@ function getExcludedItemsUnderPath(parentPath, excludedItems) {
       return 'Select an existing Catalog model to use as the parent revision.';
     }
     if (matchMode !== 'existing') {
+      // Issue #1638: show the model title when available so the user sees the
+      // intended name, matching the Server Intake experience.
+      if (selected && selected.primary) {
+        return destination === 'working'
+          ? String(selected.primary) + ' — new Working Files folder'
+          : String(selected.primary) + ' — new Catalog model';
+      }
       return destination === 'working'
         ? 'Create a new Working Files folder.'
         : 'Create a new Catalog model.';


### PR DESCRIPTION
## Summary

Upload (browser) intake now shows the model name in the "Selection" field on the Choose Destination step, matching the Server Intake experience.

Related: #1638

## Problem

When using browser file upload intake, the Choose Destination step (step 3) showed "Create a new Catalog model." without the model name. Server intake showed the model name because it had `.modelmeta.json` sidecar files with `source_catalog_model_id` and `display_title`.

**Root cause:** `selected_summary` in `_syncGroupDestinationsFromPreview()` was only populated when `sourceCatalogModelId` existed. Browser uploads to a temp staging directory have no `.modelmeta.json`, so the summary was always `null`.

Additionally, `selected_summary` from the `previous` plan object would override any recalculated value via `Object.assign`, so even if the user renamed the model in the Organize step, the stale `null` persisted.

## Changes

### `model-catalog-intake-wizard-overrides.js`
- **`_syncGroupDestinationsFromPreview()`**: Compute `autoSummary` from `model.title` when no `source_catalog_model_id` is available. For `match_mode === 'new'`, always apply the fresh `autoSummary` (no user lookup selection to preserve), so title renames in the Organize step are reflected immediately.
- **`_destinationSelectionSummary()`**: For 'new' match mode, display the model name (e.g. `"My Model — new Catalog model"`) instead of the generic `"Create a new Catalog model."`.

### Version bumps
- `model-catalog-intake-cards.js`: overrides import v140 → v141
- `_resources.yaml`: intake-cards v257 → v258

## Testing

- Existing `test_intake_plan_sidecar_metadata.py` tests pass (7/7).
- Server intake behavior is unchanged (auto-detected metadata still populates `selected_summary` with `sourceCatalogModelId`).

> **Note:** After deploy, hard refresh the browser so the updated module URL is fetched immediately.