### PR TITLE
fix: correct broken image paths in documentation

### DIFF
--- a/docs/features/air_quality/reference/visual-preview.md
+++ b/docs/features/air_quality/reference/visual-preview.md
@@ -4,7 +4,7 @@ This document shows what your air quality dashboard will look like after configu
 
 <!-- SCREENSHOT: id=air-quality-visual-good | format=png | version=1.0 | package=air_quality | added=2026-03-15 | captured=2026-03-15 -->
 
-![Air quality sensors — good state (all green)](../../screenshots/images/air-quality-sensors-good.png)
+![Air quality sensors — good state (all green)](../../../screenshots/images/air-quality-sensors-good.png)
 
 <!-- SCREENSHOT: id=air-quality-visual-moderate | format=png | version=1.0 | package=air_quality | added=2026-03-15 -->
 <!-- Capture: Sensor cards with yellow/moderate indicators (during PLA print) -->

--- a/docs/features/printer_controls/design/fan-controls-visual.md
+++ b/docs/features/printer_controls/design/fan-controls-visual.md
@@ -4,7 +4,7 @@ This document provides visual examples of how the fan control cards appear in di
 
 <!-- SCREENSHOT: id=fan-controls-printing | format=png | version=1.0 | package=printer_controls | added=2026-03-15 | captured=2026-03-15 -->
 
-![Fan controls — all fans active during print](/docs/screenshots/images/fan-controls-printing.png)
+![Fan controls — all fans active during print](../../../screenshots/images/fan-controls-printing.png)
 
 <!-- SCREENSHOT: id=fan-controls-idle | format=png | version=1.0 | package=printer_controls | added=2026-03-15 -->
 <!-- Capture: All 4 fan cards when idle — grey icons, 0%/Off values -->

--- a/docs/features/printer_dashboards/README.md
+++ b/docs/features/printer_dashboards/README.md
@@ -18,7 +18,7 @@ Each feature package contributes cards via its `dashboard_cards/` directory, whi
 
 <!-- SCREENSHOT: id=dashboard-full-desktop | format=png | version=1.0 | package=printer_dashboards | added=2026-03-15 | captured=2026-03-15 -->
 
-![Full dashboard — desktop overview](/docs/screenshots/images/dashboard-full-desktop.png)
+![Full dashboard — desktop overview](../../screenshots/images/dashboard-full-desktop.png)
 
 <!-- SCREENSHOT: id=dashboard-full-mobile | format=png | version=1.0 | package=printer_dashboards | added=2026-03-15 | captured=2026-03-15 -->
 

--- a/docs/features/printer_dashboards/design/ams-tray-popup-visual.md
+++ b/docs/features/printer_dashboards/design/ams-tray-popup-visual.md
@@ -7,7 +7,7 @@ The popup is built dynamically in JavaScript at click-time, so all values (color
 
 <!-- SCREENSHOT: id=ams-popup-full-matched | format=png | version=1.0 | package=printer_dashboards | added=2026-03-15 | captured=2026-03-15 -->
 
-![AMS tray popup — full matched spool view](/docs/screenshots/images/ams-popup-full-matched.png)
+![AMS tray popup — full matched spool view](../../../screenshots/images/ams-popup-full-matched.png)
 
 <!-- SCREENSHOT: id=ams-popup-no-spool | format=png | version=1.0 | package=printer_dashboards | added=2026-03-15 | captured=2026-03-15 -->
 

--- a/docs/features/printer_led/reference/led-controls/visual-reference.md
+++ b/docs/features/printer_led/reference/led-controls/visual-reference.md
@@ -2,7 +2,7 @@
 
 <!-- SCREENSHOT: id=led-visual-full-grid | format=png | version=1.0 | package=printer_led | added=2026-03-15 | captured=2026-03-15 -->
 
-![LED controls — full 7-light grid](../../screenshots/images/led-controls-compact.png)
+![LED controls — full 7-light grid](../../../../screenshots/images/led-controls-compact.png)
 
 <!-- SCREENSHOT: id=led-visual-wled-popup | format=png | version=1.0 | package=printer_led | added=2026-03-15 -->
 <!-- Capture: WLED advanced popup dialog showing effect/palette/speed/intensity controls and color picker -->

--- a/docs/features/spoolman_sync/reference/active-tray-changed-update-automation.md
+++ b/docs/features/spoolman_sync/reference/active-tray-changed-update-automation.md
@@ -57,5 +57,5 @@ The automation also suppresses persistent error notifications for indeterminate 
 
 ## Flow of the Logic
 
-![Flow Chart describing the Active Tray Changed automation](assets/bambu-printer-automations-tray-updated.png)
+![Flow Chart describing the Active Tray Changed automation](../assets/bambu-printer-automations-tray-updated.png)
 

--- a/docs/features/spoolman_sync/reference/find-matching-spool-script.md
+++ b/docs/features/spoolman_sync/reference/find-matching-spool-script.md
@@ -62,4 +62,4 @@ If unsuccessful (cannot find a match): the script will return a failure and erro
 
 ## Flowchart of Logic:
 
-![Flowchart showing the script logic](assets/bambu-printer-automations-find-spool.png)
+![Flowchart showing the script logic](../assets/bambu-printer-automations-find-spool.png)

--- a/docs/features/spoolman_sync/reference/print-complete-update-filament-usage.md
+++ b/docs/features/spoolman_sync/reference/print-complete-update-filament-usage.md
@@ -50,5 +50,5 @@ This Home Assistant automation triggers upon a successful completion of a print 
 
 ## Flow of the Logic
 
-![Flow Chart describing the Print Complete automation](assets/bambu-printer-automations-print-complete.png)
+![Flow Chart describing the Print Complete automation](../assets/bambu-printer-automations-print-complete.png)
 

--- a/docs/features/spoolman_sync/reference/reload-spoolman-integration-automation.md
+++ b/docs/features/spoolman_sync/reference/reload-spoolman-integration-automation.md
@@ -22,5 +22,5 @@ Each night at 11pm this will force a reload of the Spoolman integration. This se
 
 ## Flow of the Logic
 
-![Flow Chart describing the Reload Spoolman Integration automation](assets/bambu-printer-automations-spoolman-refresh.png)
+![Flow Chart describing the Reload Spoolman Integration automation](../assets/bambu-printer-automations-spoolman-refresh.png)
 


### PR DESCRIPTION
## Summary

Fixes 9 broken image paths that were causing Docusaurus build failures.

## Issues Fixed

| File | Problem | Fix |
|------|---------|-----|
| air_quality/reference/visual-preview.md | Relative path too shallow | Added extra ../ |
| printer_led/reference/led-controls/visual-reference.md | Relative path too shallow | Added extra ../../ |
| printer_controls/design/fan-controls-visual.md | Absolute /docs/ prefix | Converted to relative |
| printer_dashboards/README.md | Absolute /docs/ prefix | Converted to relative |
| printer_dashboards/design/ams-tray-popup-visual.md | Absolute /docs/ prefix | Converted to relative |
| 4x spoolman_sync/reference/*.md | assets/ resolves inside reference/ | Changed to ../assets/ |

All referenced images already exist on disk — only the paths were wrong.