### PR TITLE
docs: Bambuddy v0.2.5 / Spoolman v0.23.x release review specs

### DIFF
--- a/docs/features/bambuddy_common/planning/release-review-2026-07/README.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/README.md
@@ -1,0 +1,33 @@
+# Bambuddy & Spoolman Release Review — July 2026
+
+## Overview
+
+This directory contains spec documents assessing new releases of Bambuddy (v0.2.5 beta / v0.1.6 stable) and Spoolman (v0.23.0 / v0.23.1) against our `hass-bambulab-config` integration surface area.
+
+## Releases Reviewed
+
+| Software | Version | Type | Date |
+|----------|---------|------|------|
+| Bambuddy | v0.1.6 | Stable | 2026-01-31 |
+| Bambuddy | v0.2.5b2-daily.20260706 | Daily Beta | 2026-07-06 |
+| Spoolman | v0.23.0 | Stable | 2026-01-?? |
+| Spoolman | v0.23.1 | Stable | 2026-02-?? |
+
+## Spec Documents
+
+| Document | Topic | Impact |
+|----------|-------|--------|
+| [build-plate-detection.md](./build-plate-detection.md) | Build Plate Detection — entities, storage, usage | New capability |
+| [model-queue-scheduling.md](./model-queue-scheduling.md) | Model-based Queue — relevance assessment | Assessment |
+| [advanced-auth.md](./advanced-auth.md) | Advanced Authentication — work & considerations | Configuration |
+| [prometheus-bambuddy-metrics.md](./prometheus-bambuddy-metrics.md) | Bambuddy Prometheus Metrics endpoint | New capability |
+| [external-camera-fix.md](./external-camera-fix.md) | External Camera transcoding fix — impact analysis | Low impact |
+| [spoolman-adjust-spool.md](./spoolman-adjust-spool.md) | Adjust Spool / Measured Weight — API & coordination | Integration risk |
+| [pwa-sidebar-embedding.md](./pwa-sidebar-embedding.md) | PWA support for Spoolman — future ideas | Future |
+| [cors-considerations.md](./cors-considerations.md) | CORS variable — when it matters and how to configure | Configuration |
+
+## Summary Verdict
+
+- **Breaking changes:** None. Both releases are backwards-compatible.
+- **Action required:** Auth considerations if upgrading to Bambuddy v0.2.x; Spoolman `adjust spool` coordination with our automations.
+- **New opportunities:** Build plate tracking, Bambuddy native Prometheus metrics, queue scheduling enrichment.

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/advanced-auth.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/advanced-auth.md
@@ -1,0 +1,92 @@
+# Advanced Authentication — Considerations & Work
+
+## Feature Summary
+
+Bambuddy v0.1.6 introduced **optional authentication** with API keys. The v0.2.x branch expands this dramatically:
+
+- SSO/OIDC/LDAP/Active Directory integration
+- Two-Factor Authentication (TOTP, email OTP, backup codes)
+- Self-service password resets
+- Role and group-based permissions (50+ granular controls)
+
+## Current State in Our Config
+
+We use **API key authentication** for all Bambuddy REST calls:
+
+```yaml
+# From bambuddy/sensors.yaml
+headers:
+  X-API-Key: "{{ states('input_text.bambuddy_api_key') }}"
+  Content-Type: application/json
+```
+
+The API key is stored in:
+- `input_text.bambuddy_api_key` — HA helper entity (likely in secrets or manual config)
+
+All REST sensors, REST commands, and shell commands that talk to Bambuddy use this pattern.
+
+## Impact Assessment
+
+### No Breaking Change (v0.1.6 → v0.2.x)
+
+API key auth remains supported. The advanced auth features are **additive** — they don't replace the `X-API-Key` header mechanism. Our existing config will continue to work.
+
+### Considerations for Future
+
+| Concern | Detail | Priority |
+|---------|--------|----------|
+| Key rotation | If RBAC is enabled, API keys may have expiration policies | Medium |
+| Scoped permissions | New granular controls could restrict what our API key can do | Medium |
+| OIDC/SSO impact on sidebar | If Bambuddy enforces SSO, the sidebar embed may need session cookies | Low |
+| Multi-user access | If other users access Bambuddy, our HA automations should use a dedicated service account key | Low |
+
+## Work To Be Done
+
+### Immediate (on upgrade to v0.2.x)
+
+1. **Verify API key still works** — After upgrading, confirm all REST sensors return 200.
+2. **Check key permissions** — If RBAC is enabled by default, ensure the API key has at minimum:
+   - `archives:read`, `archives:write` (print history)
+   - `queue:read`, `queue:write` (print queue)
+   - `printers:read` (printer status)
+   - `statistics:read` (statistics)
+   - `photos:write` (snapshot uploads)
+3. **Document the key** — Record which permissions our integration needs in case the key needs recreation.
+
+### If Enabling Advanced Auth
+
+1. **Create a dedicated HA service account** in Bambuddy with only the permissions our automations need (principle of least privilege).
+2. **Store credentials securely**:
+   - Move API key to `secrets.yaml` if not already there
+   - Consider HA's built-in credential store
+3. **Test all integration points**:
+   - REST sensors (4 polling sensors)
+   - REST commands (archive detail, query, patch)
+   - Shell commands (photo upload via curl)
+   - Custom integration services (`bambuddy.append_print_history_event`, etc.)
+4. **Sidebar / iframe considerations** — If Bambuddy is embedded in HA sidebar via iframe, OIDC login may require:
+   - Setting `X-Frame-Options: ALLOW-FROM` on Bambuddy
+   - Or using a pre-authenticated session cookie approach
+
+### If NOT Enabling Advanced Auth
+
+No work required. Keep using API key as-is.
+
+## Affected Files
+
+```
+bambuddy/sensors.yaml                              — All REST sensors use X-API-Key
+bambuddy/rest_commands.yaml                        — REST commands use X-API-Key
+homeassistant/packages/3d_printing/print_history/
+  rest_commands/bambuddy_get_archive_detail.yaml   — Archive queries
+  rest_commands/bambuddy_query_recent_archive.yaml — Archive search
+  shell_commands/bambuddy_upload_archive_photo.yaml — Photo upload (curl with API key)
+  scripts/capture_and_upload_snapshot.yaml          — Orchestrates upload
+```
+
+## Recommendations
+
+1. **Don't enable advanced auth yet** unless there's a multi-user need. API key is sufficient for a single-user, LAN-only deployment.
+2. **When upgrading**, run a quick smoke test: verify each REST sensor shows non-error state after the upgrade.
+3. **If RBAC is enabled**, document the minimum permission set in this repo so we can recreate the key if needed.
+4. **Future-proof**: If we ever move Bambuddy behind a reverse proxy with SSO (e.g., Authelia/Authentik), we'll need to handle auth token passthrough for HA → Bambuddy API calls. Plan for this if the homelab grows.

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/build-plate-detection.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/build-plate-detection.md
@@ -1,0 +1,113 @@
+# Build Plate Detection — Spec
+
+## Feature Summary
+
+Bambuddy v0.1.6+ detects which build plate is installed on the printer. The v0.2.x branch refines this with UI feedback ("Plate 2 of 5 — Generating G-code") and integrates plate info into the queue scheduler/dispatcher.
+
+## Current State in Our Config
+
+We have **no build plate tracking** today. Our print history archives, print queue, and automations are plate-unaware.
+
+## Where This Data Lives
+
+### In Bambuddy
+
+- **Archive records**: Each archive likely now includes a `plate_type` or `build_plate` field (e.g., "Cool Plate", "Engineering Plate", "High Temp Plate", "Textured PEI").
+- **Printer status API**: `/api/v1/printers/{id}/status` may expose `current_plate` alongside existing `nozzle_temp`, `bed_temp`, etc.
+- **Queue entries**: Queue jobs can be assigned to specific plate types.
+
+### Proposed HASS Entities
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `sensor.3dprinter_current_build_plate` | Template sensor | Derived from Bambuddy printer status or Bambu Lab integration |
+| `input_select.3dprinter_installed_plate` | Input select | Manual override / fallback if auto-detection is unavailable |
+| `sensor.3dprinter_plate_print_count` | Template sensor | Track prints per plate for maintenance alerts |
+
+### Storage Options
+
+**Option A: Bambuddy-sourced (Recommended)**
+
+Pull plate info from the Bambuddy printer status REST sensor we already poll every 30s:
+
+```yaml
+# In bambuddy/sensors.yaml — extend json_attributes for Printer Status
+json_attributes:
+  - status
+  - current_print
+  - maintenance
+  - error
+  - nozzle_temp
+  - bed_temp
+  - chamber_temp
+  - print_progress
+  - time_remaining_minutes
+  - fan_speed
+  - filament
+  - build_plate          # <-- NEW
+  - build_plate_type     # <-- NEW
+```
+
+Then derive a template sensor:
+
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      bambuddy_current_build_plate:
+        friendly_name: "Current Build Plate"
+        value_template: >-
+          {{ state_attr('sensor.bambuddy_printer_status', 'build_plate_type')
+             | default('Unknown') }}
+        icon_template: mdi:tray-full
+```
+
+**Option B: Bambu Lab Integration Direct**
+
+The Bambu Lab HASS integration may expose plate detection as a sensor directly. Check for `sensor.*_build_plate` entities after upgrading the HA integration.
+
+**Option C: Hybrid**
+
+Use Bambu Lab integration for real-time plate detection, store it in a helper for use in automations, and enrich Bambuddy archives with plate info during the `bambuddy_enrich_archive_on_complete` automation.
+
+## Integration Points
+
+### Print History Enrichment
+
+Extend `bambuddy_enrich_archive_on_complete` to PATCH the build plate onto the archive:
+
+```yaml
+- action: rest_command.bambuddy_patch_archive
+  data:
+    archive_id: "{{ archive_id }}"
+    payload:
+      build_plate: "{{ states('sensor.3dprinter_current_build_plate') }}"
+```
+
+### Print Queue
+
+If we adopt Bambuddy's queue scheduler, plate-type filtering becomes available — only dispatch jobs compatible with the currently installed plate.
+
+### Maintenance Tracking
+
+Track plate wear:
+- Count prints per plate type via a counter or utility_meter
+- Alert when a plate exceeds N prints without cleaning/replacement
+- Could integrate with `printer_maintenance` package
+
+## Recommended Approach
+
+1. **Phase 1**: Add `build_plate` / `build_plate_type` to existing Bambuddy printer status `json_attributes`. Create a template sensor. No new entities needed beyond that.
+2. **Phase 2**: Enrich print history archives with plate info at completion time.
+3. **Phase 3**: Add plate-based maintenance counters if we find the data useful after a few weeks.
+
+## Open Questions
+
+- [ ] Does the Bambuddy API actually expose `build_plate` in the printer status response, or only in archives?
+- [ ] Does the Bambu Lab HA integration provide a native plate sensor?
+- [ ] What are the exact plate type string values? (Need API response samples)
+
+## Dependencies
+
+- Bambuddy v0.1.6+ (stable) or v0.2.x (beta)
+- Possible: updated Bambu Lab HA custom integration

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/cors-considerations.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/cors-considerations.md
@@ -1,0 +1,139 @@
+# CORS Considerations — `SPOOLMAN_CORS_ORIGIN`
+
+## Feature Summary
+
+Spoolman v0.23.0 adds the `SPOOLMAN_CORS_ORIGIN` environment variable to configure allowed CORS origins for the Spoolman API.
+
+## What is CORS and When Does It Matter?
+
+CORS (Cross-Origin Resource Sharing) restricts browser-based JavaScript from making requests to a different origin (protocol + host + port) than the page was loaded from.
+
+**CORS applies when:**
+- JavaScript in a browser makes `fetch()` / `XMLHttpRequest` calls to a different origin
+- Example: HA dashboard at `http://homeassistant.local:8123` → Spoolman API at `http://spoolman.socko.us`
+
+**CORS does NOT apply when:**
+- Server-side code (Python, shell, Node.js) makes HTTP requests
+- HA automations use `rest_command` or `rest` platform (these are server-side)
+- `curl` commands in shell_commands (server-side)
+- HA's `rest` sensor platform (server-side)
+
+## Where We Might See CORS Issues
+
+### Places CORS IS Relevant
+
+| Component | CORS Risk? | Why |
+|-----------|-----------|-----|
+| Custom Lovelace cards calling Spoolman API directly | ✅ **YES** | JS in browser → different origin |
+| Bambuddy custom cards calling Bambuddy API | ✅ **YES** | JS in browser → different origin |
+| `panel_iframe` embedding Spoolman | ⚠️ Possible | iframe itself loads fine, but cross-frame JS calls would be blocked |
+| Custom cards calling Bambuddy queue API | ✅ **YES** | `unified-queue-board-card` calls `/api/v1/queues/...` |
+
+### Places CORS is NOT Relevant
+
+| Component | CORS Risk? | Why |
+|-----------|-----------|-----|
+| `rest_command.spoolman_getspools` | ❌ No | Server-side HA call |
+| `rest_command.bambuddy_*` | ❌ No | Server-side HA call |
+| `shell_command.bambuddy_upload_archive_photo` | ❌ No | Server-side curl |
+| REST sensor platform (bambuddy/sensors.yaml) | ❌ No | Server-side HA polling |
+| Template sensors | ❌ No | Computed in HA backend |
+
+## Are We Affected?
+
+### Custom Lovelace Cards
+
+Our `homeassistant/www/3d_printing/` directory contains custom JavaScript cards that make direct API calls from the browser. These cards likely call:
+
+- **Bambuddy**: `/api/v1/queues/{printer_id}/entries`, `/api/v1/models`, etc.
+- **Spoolman**: Possibly direct spool/filament API calls for selectors or displays
+
+If any of these JS cards make `fetch()` calls to `http://spoolman.socko.us/api/...` from a page served by `http://homeassistant.local:8123`, **CORS will block them** unless Spoolman allows that origin.
+
+### Bambuddy Cards
+
+Similarly, cards calling Bambuddy's API from the browser need Bambuddy to allow the HA origin. Bambuddy likely handles this already (since it's designed for HA integration), but worth verifying.
+
+## How to Fix CORS Issues
+
+### For Spoolman
+
+Set the environment variable in your Spoolman deployment (docker-compose or systemd):
+
+```yaml
+# docker-compose.yml for Spoolman
+services:
+  spoolman:
+    image: ghcr.io/donkie/spoolman:latest
+    environment:
+      - SPOOLMAN_CORS_ORIGIN=http://homeassistant.local:8123,https://homeassistant.local:8123
+    # ... rest of config
+```
+
+Or to allow all origins (less secure, fine for LAN):
+
+```yaml
+environment:
+  - SPOOLMAN_CORS_ORIGIN=*
+```
+
+### For Bambuddy
+
+Check if Bambuddy has a similar CORS config. If running behind a reverse proxy (nginx/Traefik/Caddy), add CORS headers there:
+
+```nginx
+# nginx example
+location /api/ {
+    add_header Access-Control-Allow-Origin "http://homeassistant.local:8123";
+    add_header Access-Control-Allow-Methods "GET, POST, PATCH, PUT, DELETE, OPTIONS";
+    add_header Access-Control-Allow-Headers "Content-Type, X-API-Key, Authorization";
+    
+    if ($request_method = OPTIONS) {
+        return 204;
+    }
+    
+    proxy_pass http://bambuddy:3000;
+}
+```
+
+### Alternative: HA Proxy Approach
+
+Route all API calls through HA's own server (avoids CORS entirely):
+
+```yaml
+# In configuration.yaml — proxy Spoolman through HA
+rest_command:
+  spoolman_proxy:
+    url: "http://spoolman.socko.us/api/v1/{{ path }}"
+    method: "{{ method }}"
+    headers:
+      Content-Type: "application/json"
+    payload: "{{ payload }}"
+```
+
+Then have custom cards call `/api/services/rest_command/spoolman_proxy` — same origin, no CORS.
+
+**Downside:** More complex, adds latency, limits card flexibility.
+
+## Diagnostic Steps
+
+If you encounter CORS issues:
+
+1. Open browser DevTools → Network tab
+2. Look for red/failed requests to `spoolman.socko.us` or `bambuddy.socko.us`
+3. Check Console for: `Access-Control-Allow-Origin` errors
+4. The error message will tell you exactly which origin needs to be allowed
+
+## Recommendations
+
+1. **Proactively set `SPOOLMAN_CORS_ORIGIN`** to your HA URL(s) in the Spoolman deployment. It's free insurance.
+2. **Check Bambuddy CORS** — if our queue board card or other custom cards call Bambuddy directly from JS, verify CORS is configured.
+3. **Audit custom cards** — grep `www/3d_printing/` for `fetch(` calls to identify which external APIs are called from the browser.
+4. **If using reverse proxy** — handle CORS at the proxy level for all services uniformly.
+
+## Action Items
+
+- [ ] Set `SPOOLMAN_CORS_ORIGIN=http://homeassistant.local:8123` in Spoolman docker-compose
+- [ ] Verify Bambuddy allows HA origin for API calls from browser JS
+- [ ] Audit custom JS cards for direct cross-origin API calls
+- [ ] Test after configuration: all custom cards load without console errors

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/external-camera-fix.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/external-camera-fix.md
@@ -1,0 +1,61 @@
+# External Camera Fix — Impact Analysis
+
+## Feature Summary
+
+Bambuddy v0.2.5b2 fixes a bug where cameras configured in HTTP-snapshot mode that served non-JPEG images (PNG, WebP, BMP) would cause browser errors and break plate detection and photo finishing. Bambuddy now auto-transcodes non-JPEG snapshots to JPEG via OpenCV.
+
+## Our Camera Architecture
+
+We do **NOT** use Bambuddy's camera system for image capture. Our architecture is:
+
+```
+HA Camera Entity (camera.ntk_ryansoffice_3dprinter_camera)
+       ↓
+HA camera.snapshot service → /config/www/printer_snapshots/*.jpg
+       ↓
+shell_command.bambuddy_upload_archive_photo (curl multipart POST)
+       ↓
+Bambuddy Archive (receives JPEG)
+```
+
+Key facts:
+- We capture via HA's `camera.snapshot` action — this always produces JPEG
+- We upload the JPEG file to Bambuddy via `curl` multipart form
+- We do NOT point Bambuddy at a camera URL for it to pull from
+- We do NOT rely on Bambuddy's camera streaming or snapshot-pull features
+
+## Impact Assessment
+
+**Impact: NONE for our current setup.**
+
+This fix is relevant for users who:
+1. Configure a camera URL *within Bambuddy's settings* (not HA)
+2. Have that camera URL return non-JPEG content
+3. Rely on Bambuddy's internal plate-detection or photo-finishing from that camera
+
+Since we handle all camera work in HA and push pre-captured JPEG files, this bug and fix are completely transparent to us.
+
+## Edge Cases to Consider
+
+### If We Ever Add Bambuddy-Side Camera Config
+
+If in the future we configure Bambuddy to pull directly from an HA camera's snapshot URL (e.g., `http://homeassistant.local:8123/api/camera_proxy/camera.xxx`), then:
+- HA camera proxy serves JPEG by default ✓
+- No issue expected even without this fix
+
+### If We Add Non-JPEG Camera Sources to HA
+
+If we add a camera to `input_text.bambuddy_capture_camera_entities` that produces PNG output:
+- HA's `camera.snapshot` converts to JPEG at capture time ✓
+- Our upload sends `.jpg` files ✓
+- No issue
+
+## Recommendation
+
+**No action needed.** This fix is a "nice to have" safety net but doesn't affect our workflow. Document this finding and move on.
+
+## Files Reviewed
+
+- `homeassistant/packages/3d_printing/print_history/scripts/capture_and_upload_snapshot.yaml`
+- `homeassistant/packages/3d_printing/print_history/shell_commands/bambuddy_upload_archive_photo.yaml`
+- `homeassistant/packages/3d_printing/bambuddy_integration/automations/bambuddy_upload_snapshot.yaml`

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/model-queue-scheduling.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/model-queue-scheduling.md
@@ -1,0 +1,84 @@
+# Model-Based Queue Scheduling — Relevance Assessment
+
+## Feature Summary
+
+Bambuddy v0.1.6 introduced a drag-and-drop print queue with:
+- Model/printer assignment
+- Multi-printer support with scheduled prints
+- Plate mapping and dispatch integration
+- AMS (Automatic Material System) re-print mapping
+
+The v0.2.x branch refines this with more robust scheduling, farm-wide dispatch, and print pre-staging.
+
+## Current State in Our Config
+
+We **already have a queue implementation** in our config:
+
+```
+homeassistant/packages/3d_printing/print_queue/
+├── dashboard_views/print_queue_board.yaml    # custom:unified-queue-board-card
+├── print_queue_loader.yaml                   # Loader with REST API references
+├── DEPLOYMENT_VALIDATION.md
+├── MIGRATION_CHECKLIST.md
+└── README.md
+```
+
+Our queue card calls:
+- `/api/v1/queues/{printer_id}/entries` — Queue REST API
+- `/api/v1/models` — Model catalog for add modal
+- `/api/v1/working-files` — Working files for add modal
+
+## Assessment: Do We Use Bambuddy's Queue?
+
+**Yes, heavily.** Our `unified-queue-board-card` is a custom Lovelace card that talks directly to Bambuddy's queue API. We are consumers of this feature.
+
+### What's Relevant
+
+| Feature | Relevant? | Notes |
+|---------|-----------|-------|
+| Drag-and-drop queue | ✅ Yes | Already integrated in our board card |
+| Model assignment | ✅ Yes | Our add modal pulls from `/api/v1/models` |
+| Multi-printer support | ⚠️ Future | We currently have 1 printer (`p1`) |
+| Scheduled prints (time-based) | ✅ Yes | Could enrich our queue card with schedule info |
+| Plate mapping | ✅ Yes | Ties into build-plate-detection spec |
+| AMS re-print mapping | ✅ Yes | Connects to our spoolman_sync tray assignment |
+| Farm-wide dispatch (v0.2.x) | ❌ Not now | Single printer setup |
+| Print pre-staging | ⚠️ Future | Interesting for overnight batch printing |
+
+### What's NOT Relevant (Yet)
+
+- Farm-wide dispatch — we have one printer
+- Virtual printer mode — we don't use slicer integration through Bambuddy
+
+## Impact of Queue API Changes
+
+### New Fields to Surface
+
+If the queue API now returns additional fields, our `unified-queue-board-card` may benefit from:
+
+```
+scheduled_at       — When the job is scheduled to start
+assigned_plate     — Which plate type is required
+ams_mapping        — Which AMS slots are assigned
+estimated_duration — Print time estimate
+priority           — Job priority / rank
+```
+
+### Action Items
+
+1. **Verify API response shape** — Hit `/api/v1/queues/p1/entries` after upgrading and inspect for new fields.
+2. **Update card if needed** — If new fields are present, the `unified-queue-board-card` JS may need updates to display schedule time, plate requirements, etc.
+3. **Consider planner integration** — Our card already has a "Queue planner with strategy selector" (aggressive/balanced/lazy). Verify this still works with the updated API.
+
+## Recommendations
+
+- **No breaking changes expected.** The queue API is additive.
+- **Opportunity:** Add `scheduled_at` display to queue entries for overnight batch planning.
+- **Opportunity:** Connect plate assignment to the build-plate-detection sensor for "plate mismatch" warnings.
+- **Low priority:** Multi-printer support is not needed until we add a second printer.
+
+## Dependencies
+
+- `homeassistant/www/3d_printing/` — unified-queue-board-card JS
+- `homeassistant/packages/3d_printing/print_queue/` — package loader
+- Bambuddy v0.1.6+ queue API

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/prometheus-bambuddy-metrics.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/prometheus-bambuddy-metrics.md
@@ -1,0 +1,161 @@
+# Bambuddy Prometheus Metrics — Spec
+
+## Feature Summary
+
+Bambuddy v0.2.x exposes a native **Prometheus metrics endpoint**, likely at `/metrics` or `/api/v1/metrics`. This provides printer and print-farm metrics directly scrapeable by Prometheus without going through Home Assistant as an intermediary.
+
+## Current State in Our Config
+
+We already have a robust Prometheus integration design:
+
+- **Existing doc**: `docs/features/logging/reference/integrations/prometheus.md`
+- **Existing stack**: Prometheus, Grafana, Alertmanager, Loki/Promtail in `homelab/logging-integrations/`
+- **HA Prometheus integration**: Exports HA sensors/counters to Prometheus via `/api/prometheus`
+- **HA entities scraped**: `counter.bambulab_error_count`, `counter.bambulab_warning_count`, automation triggers, etc.
+
+### Current Flow
+
+```
+Bambu Lab Printer → HA Integration → HA Sensors → Prometheus (via HA /api/prometheus)
+                                                        ↓
+                                                     Grafana
+```
+
+## New Opportunity
+
+### Direct Bambuddy → Prometheus Scraping
+
+```
+Bambu Lab Printer → Bambuddy → Prometheus (direct scrape of /metrics)
+                       ↓              ↓
+              HA (REST sensors)    Grafana
+```
+
+This gives us **two complementary data paths**:
+1. **HA path** — automation-level metrics (errors, print completions, filament usage updates)
+2. **Bambuddy path** — printer-level metrics (temperatures, speeds, progress, queue depth)
+
+## Proposed Implementation
+
+### 1. Add Bambuddy as a Prometheus Scrape Target
+
+Add to `prometheus.yml` (alongside existing HA scrape):
+
+```yaml
+scrape_configs:
+  # Existing HA scrape
+  - job_name: 'homeassistant'
+    scrape_interval: 60s
+    metrics_path: '/api/prometheus'
+    bearer_token: 'HA_LONG_LIVED_TOKEN'
+    static_configs:
+      - targets: ['homeassistant.local:8123']
+
+  # NEW: Direct Bambuddy metrics
+  - job_name: 'bambuddy'
+    scrape_interval: 15s
+    metrics_path: '/metrics'    # Verify actual path after upgrade
+    static_configs:
+      - targets: ['bambuddy.socko.us:80']
+    # If auth required:
+    # bearer_token: 'BAMBUDDY_API_KEY'
+    # Or:
+    # params:
+    #   api_key: ['YOUR_KEY']
+```
+
+### 2. Expected Metrics from Bambuddy
+
+Based on the feature set, expect metrics like:
+
+```
+# Printer state
+bambuddy_printer_status{printer_id="p1"} 1
+bambuddy_printer_nozzle_temp_celsius{printer_id="p1"} 220.5
+bambuddy_printer_bed_temp_celsius{printer_id="p1"} 60.0
+bambuddy_printer_chamber_temp_celsius{printer_id="p1"} 35.2
+
+# Print progress
+bambuddy_print_progress_percent{printer_id="p1"} 67.3
+bambuddy_print_elapsed_seconds{printer_id="p1"} 3600
+bambuddy_print_remaining_seconds{printer_id="p1"} 1800
+
+# Queue
+bambuddy_queue_entries_total{printer_id="p1", state="pending"} 5
+bambuddy_queue_entries_total{printer_id="p1", state="completed"} 42
+
+# Totals
+bambuddy_prints_total{status="success"} 150
+bambuddy_prints_total{status="failed"} 8
+bambuddy_filament_used_grams_total 12500
+bambuddy_print_time_seconds_total 540000
+```
+
+### 3. Grafana Dashboard Additions
+
+Create a "Bambuddy Direct" dashboard panel set:
+
+| Panel | Query | Value |
+|-------|-------|-------|
+| Live Nozzle Temp | `bambuddy_printer_nozzle_temp_celsius{printer_id="p1"}` | Gauge |
+| Print Progress | `bambuddy_print_progress_percent` | Gauge (0-100%) |
+| Print Duration Histogram | `rate(bambuddy_print_time_seconds_total[1h])` | Time series |
+| Queue Depth | `bambuddy_queue_entries_total{state="pending"}` | Stat |
+| Success Rate (24h) | `increase(bambuddy_prints_total{status="success"}[24h]) / increase(bambuddy_prints_total[24h])` | Percentage |
+
+### 4. Alerting Rules
+
+Add to `prometheus-rules.yml`:
+
+```yaml
+- alert: BambuddyPrinterOffline
+  expr: up{job="bambuddy"} == 0
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Bambuddy is unreachable"
+
+- alert: BambuddyHighNozzleTemp
+  expr: bambuddy_printer_nozzle_temp_celsius > 300
+  for: 30s
+  labels:
+    severity: critical
+  annotations:
+    summary: "Nozzle temperature dangerously high: {{ $value }}°C"
+
+- alert: BambuddyQueueStalled
+  expr: bambuddy_queue_entries_total{state="pending"} > 0 and bambuddy_printer_status == 0
+  for: 30m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Queue has pending jobs but printer is idle"
+```
+
+## Deduplication Considerations
+
+We currently export some of this data via HA → Prometheus. With Bambuddy native metrics:
+
+| Metric | HA Source | Bambuddy Source | Keep Both? |
+|--------|-----------|-----------------|------------|
+| Nozzle temp | `sensor.ntk_..._nozzle_temp` | `bambuddy_printer_nozzle_temp_celsius` | No — use Bambuddy (higher resolution) |
+| Print status | `sensor.ntk_..._print_status` | `bambuddy_printer_status` | Yes — different granularity |
+| Error counts | `counter.bambulab_error_count` | N/A | Yes — HA-only |
+| Queue depth | `sensor.bambuddy_print_queue` | `bambuddy_queue_entries_total` | No — use Bambuddy |
+| Success rate | Computed from archives | `bambuddy_prints_total` | No — use Bambuddy |
+
+## Work Items
+
+1. [ ] Verify Bambuddy metrics endpoint exists and its path after upgrading to v0.2.x
+2. [ ] Determine if the endpoint requires auth (API key header? query param?)
+3. [ ] Add scrape config to existing Prometheus setup
+4. [ ] Build initial Grafana dashboard with live printer metrics
+5. [ ] Add alerting rules for temperature and availability
+6. [ ] Evaluate which HA-exported metrics become redundant
+
+## Dependencies
+
+- Bambuddy v0.2.x (metrics endpoint)
+- Existing Prometheus/Grafana stack in `homelab/logging-integrations/`
+- Network access from Prometheus container to `bambuddy.socko.us`

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/pwa-sidebar-embedding.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/pwa-sidebar-embedding.md
@@ -1,0 +1,85 @@
+# PWA Support — Future Ideas for Sidebar Embedding
+
+## Feature Summary
+
+Spoolman v0.23.0 adds **Progressive Web App (PWA) support**, meaning the Spoolman UI can be:
+- Installed as a standalone app on desktop/mobile
+- Embedded as a fullscreen app-like experience
+- Served with proper service worker caching for offline-capable UI
+
+## Current State
+
+### Spoolman in HA
+
+We likely access Spoolman via its web UI directly (`http://spoolman.socko.us`). It is not currently embedded in the HA sidebar.
+
+### Bambuddy in HA
+
+Bambuddy has a dedicated HA App/Add-on (`naked-head/homeassistant-addons`) that provides sidebar integration.
+
+## Ideas for PWA Sidebar Embedding
+
+### Option 1: HA Sidebar Panel (iframe)
+
+Add Spoolman as a sidebar entry via `configuration.yaml`:
+
+```yaml
+panel_iframe:
+  spoolman:
+    title: "Spoolman"
+    url: "http://spoolman.socko.us"
+    icon: "mdi:spool"
+    require_admin: false
+```
+
+**Pros:**
+- Zero effort, works today without PWA
+- Accessible from HA mobile app
+
+**Cons:**
+- iframe may have CORS/auth issues (see `cors-considerations.md`)
+- Not a true PWA install — just embedded web page
+- Mobile HA app may not render iframes well
+
+### Option 2: Standalone PWA Install
+
+Install Spoolman as a PWA on the phone/tablet used for print management:
+
+1. Open `http://spoolman.socko.us` in Chrome/Edge
+2. Click "Install" / "Add to Home Screen"
+3. PWA installs as a standalone app tile
+
+**Pros:**
+- Native app-like experience
+- Works offline for viewing cached spool data
+- Fast, no HA overhead
+
+**Cons:**
+- Separate from HA dashboard — context switching
+- Requires direct network access to Spoolman
+
+### Option 3: HA Companion App Shortcut
+
+Add a shortcut in the HA companion app sidebar that deep-links to Spoolman PWA:
+
+- This is just a URL link, not true integration
+- Useful for quick access from the HA mobile app
+
+### Option 4: Custom Lovelace Panel (Most Effort)
+
+Build a custom panel that wraps Spoolman API into native HA cards:
+
+- We already do this for some Spoolman data (spool lists, filament catalog)
+- PWA doesn't add value here — we'd consume the API directly
+
+## Recommendation
+
+**Short term:** Add `panel_iframe` entry for quick sidebar access. It's a one-line config change and gives convenient access without leaving HA.
+
+**Medium term:** If the iframe works well and CORS is configured (`SPOOLMAN_CORS_ORIGIN`), leave it. If not, point users to install the PWA standalone on their tablet/phone.
+
+**Long term:** We don't need to replicate Spoolman's full UI in HA. Our custom cards surface the data that matters for print workflow (spool selection, weight tracking, AMS mapping). Let Spoolman PWA handle the administrative tasks (adding new filaments, managing vendors, adjusting spools).
+
+## No Implementation Required Now
+
+This is a "nice to have" note for future reference. Our existing integration via REST API is the primary data path; the PWA/sidebar is purely a UX convenience for manual Spoolman administration.

--- a/docs/features/bambuddy_common/planning/release-review-2026-07/spoolman-adjust-spool.md
+++ b/docs/features/bambuddy_common/planning/release-review-2026-07/spoolman-adjust-spool.md
@@ -1,0 +1,158 @@
+# Spoolman Adjust Spool / Measured Weight — API & Coordination Spec
+
+## Feature Summary
+
+Spoolman v0.23.0 adds:
+1. **"Adjust Spool" button** in the UI — allows users to manually adjust a spool's remaining weight
+2. **"Measured Weight" option** — users can enter an actual measured weight (e.g., from a scale) rather than relying on calculated remaining weight
+
+## Current State in Our Config
+
+We have extensive automatic spool usage tracking:
+
+### Automatic Usage Updates (print completion)
+
+`spoolman_sync/automations/print_complete-update_filament_usage.yaml`:
+- Triggered on print finish/fail/idle
+- Reads `sensor.ntk_ryansoffice_3dprinter_print_weight` attributes per AMS tray
+- Calculates usage per spool from tray weight data
+- PATCHes Spoolman to subtract used weight from remaining
+
+### Spool PATCH Commands
+
+`spoolman_sync/rest_commands/spoolman_patch_spool_extra.yaml`:
+- PATCHes spool extra fields (metadata)
+
+### Tray-Spool Assignment
+
+Multiple automations handle AMS tray ↔ Spoolman spool binding:
+- `active_tray_changed_update_spoolman.yaml`
+- `spool_location_change_assign_tray.yaml`
+- `clear_manual_spool_override_on_tray_change.yaml`
+
+## API Changes in Spoolman 0.23.x
+
+### What Changed
+
+The Spoolman REST API likely now supports:
+
+```
+PATCH /api/v1/spool/{id}
+{
+  "remaining_weight": 750.0,        // existing field
+  "measured_weight": 750.0,         // NEW: actual scale reading
+  "weight_adjustment_source": "measured"  // NEW: how weight was set
+}
+```
+
+Or possibly a dedicated endpoint:
+
+```
+POST /api/v1/spool/{id}/adjust
+{
+  "new_weight": 750.0,
+  "method": "measured" | "manual" | "calculated"
+}
+```
+
+### What Did NOT Change
+
+- `GET /api/v1/spool` — still returns spools with `remaining_weight` ✓
+- `PATCH /api/v1/spool/{id}` with `used_weight` delta — still supported ✓
+- Our `spoolman_getspools.yaml` REST command is unaffected ✓
+
+## Risk: Conflicting Weight Updates
+
+### Scenario
+
+1. User weighs a spool on a scale → enters 680g in Spoolman UI ("Adjust Spool")
+2. Shortly after, our automation fires `print_complete-update_filament_usage`
+3. Automation subtracts 15g from what it thinks `remaining_weight` was (old cached value)
+4. Result: Weight goes from user's accurate 680g to incorrect value
+
+### Mitigation Strategies
+
+**Strategy A: Use Delta-Based Updates Only (Current Approach)**
+
+Our current automation uses `used_weight` (a delta/subtraction), not absolute `remaining_weight`. If Spoolman correctly applies deltas against current server state:
+
+```
+# Our PATCH request (conceptual):
+PATCH /api/v1/spool/42
+{ "used_weight": 15.2 }   # Subtract this from current remaining
+```
+
+This is **safe** — regardless of what the user adjusted to, we subtract the correct delta. The user's manual adjustment and our automatic subtraction compose correctly.
+
+**Strategy B: Read-Before-Write (if using absolute weight)**
+
+If our automation writes absolute `remaining_weight`:
+1. Read current weight from Spoolman
+2. Subtract usage
+3. Write new absolute weight
+
+This has a race condition window but is better than using cached values.
+
+**Strategy C: Event-Driven Sync**
+
+Listen for Spoolman websocket events to detect manual adjustments and update our cached sensor data before computing deltas.
+
+## Verification Needed
+
+1. [ ] **Confirm our PATCH uses delta (`used_weight`) vs absolute (`remaining_weight`)**
+   - Review the actual PATCH payload in the print-complete automation
+   - If delta-based → no risk
+   - If absolute → needs coordination logic
+
+2. [ ] **Test the "Adjust Spool" API call** — what does it actually send?
+   - Does it set `remaining_weight` directly?
+   - Does it create an audit trail / event?
+
+3. [ ] **Check for new API fields** in `GET /api/v1/spool/{id}` response:
+   - `last_adjusted_at`?
+   - `adjustment_method`?
+   - `measured_weight`?
+   - These could help us detect recent manual adjustments
+
+## Opportunities
+
+### Leverage Measured Weight
+
+If we add a filament scale (many exist as ESPHome projects):
+
+```yaml
+sensor:
+  - platform: esphome
+    name: "Filament Scale Weight"
+
+automation:
+  - alias: "Sync Scale Weight to Spoolman"
+    trigger:
+      - platform: state
+        entity_id: sensor.filament_scale_weight
+        for: minutes: 5  # Debounce
+    action:
+      - service: rest_command.spoolman_adjust_spool_weight
+        data:
+          spool_id: "{{ current_spool_id }}"
+          measured_weight: "{{ states('sensor.filament_scale_weight') | float }}"
+```
+
+### Surface Adjustment History
+
+If Spoolman tracks adjustment events, we could show in our dashboard:
+- "Last manual adjustment: 2 days ago (680g measured)"
+- Warning if calculated weight diverges significantly from last measured weight
+
+## Recommendations
+
+1. **Verify our update mechanism is delta-based** (it likely is, given the `print_weight` sensor approach). If so, no conflict risk.
+2. **Don't duplicate the "Adjust Spool" UI in HA** — let users do that in Spoolman's native UI (now PWA-capable).
+3. **Consider adding a "weight confidence" indicator** — if time since last measured weight exceeds a threshold, show "estimated" vs "verified" in our dashboard.
+4. **Future**: A filament scale integration could auto-call the new measured-weight API, giving us ground-truth data continuously.
+
+## Affected Files
+
+- `homeassistant/packages/3d_printing/spoolman_sync/automations/print_complete-update_filament_usage.yaml`
+- `homeassistant/packages/3d_printing/spoolman_sync/rest_commands/spoolman_patch_spool_extra.yaml`
+- `homeassistant/packages/3d_printing/spoolman_sync/template_sensors/` (various weight-related sensors)


### PR DESCRIPTION
## Why

Bambuddy (v0.2.5 beta) and Spoolman (v0.23.0/0.23.1) have new releases with features and fixes that may affect our integration surface. This PR adds structured spec documents assessing each relevant change against our existing config, identifying what matters, what doesn't, and what work to plan.

## Approach

Created a release review directory at `docs/features/bambuddy_common/planning/release-review-2026-07/` with 9 spec documents -- one per topic area -- plus a README index. Each spec:

- Explains the upstream feature/change
- Maps it to our existing code and entities
- Assesses impact (breaking? opportunity? no-op?)
- Lists concrete work items where applicable

## Key Findings

- **No breaking changes** in either release
- **Build plate detection** -- new capability we can surface with minimal effort (add to existing REST sensor attrs)
- **Queue scheduling** -- we already consume the queue API heavily; additive fields may enrich our board card
- **Spoolman adjust-spool** -- needs verification that our filament tracking uses delta-based updates (likely safe, but should confirm)
- **Prometheus metrics** -- direct Bambuddy scraping would complement our HA-exported metrics pipeline
- **External camera fix** -- confirmed no impact; we capture in HA and push JPEG
- **CORS / Auth** -- proactive config needed before upgrading

## Linked Issues

- #1645 -- CORS + auth upgrade prep
- #1646 -- Build plate detection entity
- #1647 -- Prometheus direct scrape
- #1648 -- Spoolman adjust-spool coordination