### PR TITLE
feat(docs): add .docs-site.json for multi-repo docs site

### DIFF
--- a/.docs-site.json
+++ b/.docs-site.json
@@ -1,0 +1,9 @@
+{
+  "label": "HA 3D Printing",
+  "description": "Home Assistant integration with Bambu Lab 3D printers and associated services, devices, and automation workflows.",
+  "emoji": "🖨️",
+  "order": 30,
+  "sidebarId": "hass3dprintingSidebar",
+  "navbar": true,
+  "homepage": true
+}


### PR DESCRIPTION
Add \.docs-site.json\ metadata file at the repo root so the Docusaurus multi-repo documentation site can discover and properly label this repo's docs.

This file controls:
- **label**: Display name in navbar and homepage ('HA 3D Printing')
- **description**: Homepage card description
- **emoji**: Visual indicator
- **order**: Sort position in navbar (30 = after Homelab and Ideation)
- **navbar/homepage**: Visibility flags