### PR TITLE
fix(ci): preserve reusable GitHub runners

### DIFF
--- a/docs/infrastructure/reference/github-runner-README.md
+++ b/docs/infrastructure/reference/github-runner-README.md
@@ -1,6 +1,6 @@
 # GitHub Self-Hosted Runner (Docker / Dockhand)
 
-This stack runs a persistent GitHub Actions self-hosted runner in Docker so you can execute deploy/validation workflows from your homelab network.
+This stack runs persistent GitHub Actions self-hosted runners in Docker so you can execute deploy, validation, and image-build workflows from your homelab network.
 
 ## Why this approach
 
@@ -12,6 +12,14 @@ This stack runs a persistent GitHub Actions self-hosted runner in Docker so you 
 
 - `compose.yaml` - runner service definition
 - `.env.example` - environment variables template
+
+## Persistence contract
+
+The `ha` and `build` services use separate `/runner` bind mounts. Each mount is wired to `CONFIGURED_ACTIONS_RUNNER_FILES_DIR=/runner`, and `DISABLE_AUTOMATIC_DEREGISTRATION=true` preserves the registration when its container stops. Never share one runner-data directory between the two services.
+
+Leave `EPHEMERAL` and `BUILD_RUNNER_EPHEMERAL` unset or empty. `myoung34/github-runner` treats any non-empty value, including `false`, as enabling `--ephemeral`. A non-empty value is appropriate only for an intentionally ephemeral lane.
+
+Do not set `DISABLE_AUTO_UPDATE` unless you intentionally want to pin the bundled runner version. The image treats the presence of that variable as disabling updates, even when its value appears falsey.
 
 ## Setup
 
@@ -78,7 +86,35 @@ The workflow `.github/workflows/deploy-homeassistant-template.yml` uses rsync al
 
 ## Dockhand deployment
 
-Deploy this folder as one stack in Dockhand (same as your other compose stacks). The service is self-contained and only needs the `.env` file.
+Deploy `homelab/github-runner` as one stack in Dockhand.
+
+For an existing stack:
+
+1. Update its Compose source, and remove or empty `EPHEMERAL`, `BUILD_RUNNER_EPHEMERAL`, `HA_GH_RUNNER_EPHEMERAL`, and `HA_GH_BUILD_RUNNER_EPHEMERAL`. In particular, do not leave any of them set to `false`.
+2. Safely check only the persistence-related rendered values:
+
+   ```bash
+   docker compose -f compose.yaml config \
+     | grep -E 'EPHEMERAL:|CONFIGURED_ACTIONS_RUNNER_FILES_DIR:|DISABLE_AUTOMATIC_DEREGISTRATION:'
+   ```
+
+   Both services must render an empty `EPHEMERAL`, `/runner` for `CONFIGURED_ACTIONS_RUNNER_FILES_DIR`, and `"true"` for `DISABLE_AUTOMATIC_DEREGISTRATION`.
+3. Use Dockhand's **Redeploy** action with image pull and container recreation enabled. The shell equivalent is:
+
+   ```bash
+   docker compose -f compose.yaml pull
+   docker compose -f compose.yaml up -d --force-recreate
+   ```
+
+4. Verify reuse and service health without displaying credentials:
+
+   ```bash
+   docker compose -f compose.yaml logs --since=10m github-runner github-runner-build \
+     | grep -E 'Runner reusage is enabled|already been configured|Storing data'
+   docker compose -f compose.yaml ps
+   ```
+
+5. Confirm the `ha` and `build` runners are **Online** in GitHub, run `Runner Smoke Test` plus one build workflow, restart the stack, and repeat the log/status checks. The same runner names should return online and logs should say they were already configured.
 
 ## Example workflow target
 

--- a/homelab/github-runner/.env.example
+++ b/homelab/github-runner/.env.example
@@ -15,7 +15,9 @@ RUNNER_NAME=${HA_GH_RUNNER_NAME:-ha-dockhand-runner}
 LABELS=${HA_GH_RUNNER_LABELS:-self-hosted,linux,docker,ha,homelab,dockhand}
 RUNNER_WORKDIR=${HA_GH_RUNNER_WORKDIR:-_work}
 RUNNER_GROUP=${HA_GH_RUNNER_GROUP:-Default}
-EPHEMERAL=${HA_GH_RUNNER_EPHEMERAL:-false}
+# Leave empty for a persistent/reusable runner. Any non-empty value, including
+# "false", enables myoung34/github-runner's --ephemeral mode.
+EPHEMERAL=${HA_GH_RUNNER_EPHEMERAL:-}
 
 # NOTE: Do not set DISABLE_AUTO_UPDATE unless you explicitly want to disable runner
 # self-updates. For this image, the presence of the variable is enough to disable
@@ -31,7 +33,8 @@ BUILD_RUNNER_NAME=${HA_GH_BUILD_RUNNER_NAME:-ha-dockhand-build-runner}
 BUILD_RUNNER_LABELS=${HA_GH_BUILD_RUNNER_LABELS:-self-hosted,linux,docker,build,homelab,dockhand}
 BUILD_RUNNER_WORKDIR=${HA_GH_BUILD_RUNNER_WORKDIR:-_work_build}
 BUILD_RUNNER_GROUP=${HA_GH_BUILD_RUNNER_GROUP:-${HA_GH_RUNNER_GROUP:-Default}}
-BUILD_RUNNER_EPHEMERAL=${HA_GH_BUILD_RUNNER_EPHEMERAL:-${HA_GH_RUNNER_EPHEMERAL:-false}}
+# Set to a non-empty value only for an intentionally ephemeral build runner.
+BUILD_RUNNER_EPHEMERAL=${HA_GH_BUILD_RUNNER_EPHEMERAL:-${HA_GH_RUNNER_EPHEMERAL:-}}
 
 # Same warning for the build runner. Leave this unset unless you intentionally want
 # to pin the bundled runner version and accept upgrade drift risk.

--- a/homelab/github-runner/README.md
+++ b/homelab/github-runner/README.md
@@ -19,6 +19,10 @@ This split lets image builds run in parallel with deploy jobs while keeping the 
 
 The two services intentionally use different runner names, labels, workdirs, and `/runner` data volumes. Do not point both services at the same runner data directory.
 
+Both lanes are persistent/reusable by default. The bind-mounted `runner-data` directories are passed to the image as `CONFIGURED_ACTIONS_RUNNER_FILES_DIR=/runner`, and `DISABLE_AUTOMATIC_DEREGISTRATION=true` prevents a normal container stop from deregistering the saved runner. These settings are a required pair for `myoung34/github-runner` reuse.
+
+`EPHEMERAL` and `BUILD_RUNNER_EPHEMERAL` must be unset or empty for persistent runners. The image treats **any** non-empty value, including the string `false`, as enabling `--ephemeral`. Set one to a non-empty value only when intentionally converting that lane to an ephemeral runner; do not combine ephemeral mode with an expectation that its registration will be reused.
+
 For `myoung34/github-runner`, do not set `DISABLE_AUTO_UPDATE` unless you intentionally want to pin the bundled runner version. In practice the presence of that variable can disable self-updates even when the value is `false`.
 
 ## Files
@@ -183,6 +187,36 @@ This is intended to catch likely UI-vs-YAML naming collisions early. Keep `fail_
 ## Dockhand deployment
 
 Deploy this folder as one stack in Dockhand (same as your other compose stacks). The service is self-contained and uses `.env` placeholders resolved by Dockhand variables.
+
+### Redeploy persistent runners
+
+1. Update the Dockhand stack from this repository's `homelab/github-runner/compose.yaml`.
+2. In the stack variables, delete `EPHEMERAL` and `BUILD_RUNNER_EPHEMERAL`, or set them to empty strings. Also delete any global `HA_GH_RUNNER_EPHEMERAL` and `HA_GH_BUILD_RUNNER_EPHEMERAL` values set to `false`.
+3. Preview the rendered Compose configuration without printing credentials:
+
+   ```bash
+   docker compose -f compose.yaml config \
+     | grep -E 'EPHEMERAL:|CONFIGURED_ACTIONS_RUNNER_FILES_DIR:|DISABLE_AUTOMATIC_DEREGISTRATION:'
+   ```
+
+   Each service must show an empty `EPHEMERAL`, `/runner` for `CONFIGURED_ACTIONS_RUNNER_FILES_DIR`, and `"true"` for `DISABLE_AUTOMATIC_DEREGISTRATION`.
+4. In Dockhand, pull the latest image and use **Redeploy** with container recreation enabled. From a shell, the equivalent is:
+
+   ```bash
+   docker compose -f compose.yaml pull
+   docker compose -f compose.yaml up -d --force-recreate
+   ```
+
+5. Confirm both services reused or stored their registrations:
+
+   ```bash
+   docker compose -f compose.yaml logs --since=10m github-runner github-runner-build \
+     | grep -E 'Runner reusage is enabled|already been configured|Storing data'
+   docker compose -f compose.yaml ps
+   ```
+
+6. Confirm both named runners are **Online** under repository **Settings -> Actions -> Runners**, then dispatch `Runner Smoke Test` for the `ha` lane and one image-build workflow for the `build` lane.
+7. Restart the stack once and repeat steps 5-6. The logs should report that each runner was already configured, and GitHub should show the same runner names online without replacement registrations.
 
 ## Traefik guidance
 

--- a/homelab/github-runner/compose.yaml
+++ b/homelab/github-runner/compose.yaml
@@ -14,7 +14,9 @@ services:
       LABELS: ${LABELS:-self-hosted,linux,docker,ha,homelab,dockhand}
       RUNNER_WORKDIR: ${RUNNER_WORKDIR:-_work}
       RUNNER_GROUP: ${RUNNER_GROUP:-Default}
-      EPHEMERAL: ${EPHEMERAL:-false}
+      CONFIGURED_ACTIONS_RUNNER_FILES_DIR: /runner
+      DISABLE_AUTOMATIC_DEREGISTRATION: "true"
+      EPHEMERAL: ${EPHEMERAL:-}
       ACCESS_TOKEN: ${ACCESS_TOKEN}
     volumes:
       - ./runner-data:/runner
@@ -39,7 +41,9 @@ services:
       LABELS: ${BUILD_RUNNER_LABELS:-self-hosted,linux,docker,build,homelab,dockhand}
       RUNNER_WORKDIR: ${BUILD_RUNNER_WORKDIR:-_work_build}
       RUNNER_GROUP: ${BUILD_RUNNER_GROUP:-${RUNNER_GROUP:-Default}}
-      EPHEMERAL: ${BUILD_RUNNER_EPHEMERAL:-${EPHEMERAL:-false}}
+      CONFIGURED_ACTIONS_RUNNER_FILES_DIR: /runner
+      DISABLE_AUTOMATIC_DEREGISTRATION: "true"
+      EPHEMERAL: ${BUILD_RUNNER_EPHEMERAL:-${EPHEMERAL:-}}
       ACCESS_TOKEN: ${ACCESS_TOKEN}
     volumes:
       - ./runner-data-build:/runner

--- a/tests/tools/test_github_runner_compose.py
+++ b/tests/tools/test_github_runner_compose.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_DIR = REPO_ROOT / "homelab" / "github-runner"
+
+
+def test_runner_services_preserve_reusable_registrations() -> None:
+    compose = yaml.safe_load((RUNNER_DIR / "compose.yaml").read_text(encoding="utf-8"))
+
+    expected_data_mounts = {
+        "github-runner": "./runner-data:/runner",
+        "github-runner-build": "./runner-data-build:/runner",
+    }
+
+    for service_name, expected_data_mount in expected_data_mounts.items():
+        service = compose["services"][service_name]
+        environment = service["environment"]
+
+        assert environment["CONFIGURED_ACTIONS_RUNNER_FILES_DIR"] == "/runner"
+        assert environment["DISABLE_AUTOMATIC_DEREGISTRATION"] == "true"
+        assert expected_data_mount in service["volumes"]
+
+
+def test_runner_services_do_not_default_ephemeral_to_false() -> None:
+    compose_text = (RUNNER_DIR / "compose.yaml").read_text(encoding="utf-8")
+    env_example = (RUNNER_DIR / ".env.example").read_text(encoding="utf-8")
+
+    assert "EPHEMERAL:-false" not in compose_text
+    assert "EPHEMERAL:-false" not in env_example
+    assert "EPHEMERAL: ${EPHEMERAL:-}" in compose_text
+    assert (
+        "EPHEMERAL: ${BUILD_RUNNER_EPHEMERAL:-${EPHEMERAL:-}}" in compose_text
+    )


### PR DESCRIPTION
## Summary
- leave `EPHEMERAL` empty by default for both runner lanes while preserving explicit opt-in
- persist each registration through its existing dedicated `/runner` mount using `CONFIGURED_ACTIONS_RUNNER_FILES_DIR`
- set `DISABLE_AUTOMATIC_DEREGISTRATION=true`, as required by upstream runner reuse
- document safe Dockhand redeploy and restart verification steps in both runner references
- add regression coverage for the reusable-runner Compose contract

## Validation
- official Docker Compose renderer: both services render `EPHEMERAL: ""`, `CONFIGURED_ACTIONS_RUNNER_FILES_DIR: /runner`, and `DISABLE_AUTOMATIC_DEREGISTRATION: "true"`
- `python -m pytest tests/tools/test_github_runner_compose.py -q` — 2 passed
- `python -m pytest tests/tools -q --ignore=tests/tools/test_run_forensics_import_queue.py` — 87 passed
- `git diff --check`
- independent diff review found no significant issues

## Existing suite baseline
A full `python -m pytest -q` run stops during collection on unrelated pre-existing issues, including a non-top-level `pytest_plugins`, syntax errors in `test_slicer_bridge.py` and `test_run_forensics_import_queue.py`, and sidecar import-path collisions. No runner-specific test failed.